### PR TITLE
Added killstreak attribute to the flamethrower

### DIFF
--- a/addons/sourcemod/scripting/dodgeball_redux.sp
+++ b/addons/sourcemod/scripting/dodgeball_redux.sp
@@ -1269,6 +1269,7 @@ public Action OnPlayerInventory(Handle event, const char[] name, bool dontBroadc
 				if(!replace_primary)
 				{
 					TF2Attrib_SetByDefIndex(wep_ent, AIRBLAST_PUSH_ATTRIBUTE, 1.0);
+					TF2Attrib_SetByDefIndex(wep_ent, 2025, 1.0);
 				}
 			}
 			else
@@ -1286,6 +1287,7 @@ public Action OnPlayerInventory(Handle event, const char[] name, bool dontBroadc
 		TF2Items_SetLevel(hItem, 69);
 		TF2Items_SetQuality(hItem, 6);
 		TF2Items_SetAttribute(hItem, 0, AIRBLAST_PUSH_ATTRIBUTE, 1.0); //Can't push other players
+		TF2Items_SetAttribute(hItem, 0, 2025, 1.0); //Adds a killstreak to the flamethrower
 		TF2Items_SetNumAttributes(hItem, 1);
 		int iWeapon = TF2Items_GiveNamedItem(client, hItem);
 		CloseHandle(hItem);


### PR DESCRIPTION
As the title says, i have added the killstreak attribute to the flamethrower, so players can use the killstreak feature that you made, without the need of owning a true killstreak flamethrower